### PR TITLE
Nav

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon-32x32.png',
   organizationName: 'UWindsorCSS', // Usually your GitHub org/user name.
-  projectName: 'wiki', // Usually your repo name.
+  projectName: 'Wiki', // Usually your repo name.
   themeConfig: {
     defaultMode: 'dark',
     navbar: {
@@ -63,8 +63,13 @@ module.exports = {
               href: 'https://css.uwindsor.ca/discord',
             },
             {
+              label: 'Github',
+              href: 'https://github.com/UWindsorCSS'
+
+            },
+            {
               label: 'Twitter',
-              href: 'https://twitter.com/docusaurus',
+              href: 'https://twitter.com/UWindsorCSS',
             },
           ],
         },
@@ -87,11 +92,10 @@ module.exports = {
               label: 'facebook',
               href: 'https://www.facebook.com/uwindsorcss',
             },
-
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Computer Science Society, Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} University of Windsor Computer Science Society`,
     },
   },
   presets: [

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -64,8 +64,8 @@ nav {
 
 /* to keep dark mode colours while in mobile mode*/
 /* it doesnt follow darkmode always rules while side panel*/
-.menu__link {
-  color: rgb(245, 246, 247);
+.navbar-sidebar__items .menu .menu__list .menu__list-item .menu__link{
+  color: rgb(245, 246, 247) !important;
 }
 
 /* Github logo */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,7 @@
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
+
 }
 
 /* to make it fit content not the box */
@@ -27,6 +28,10 @@ nav {
   --ifm-navbar-background-color: #212529;
   padding: 1rem 0rem;
   align-content: center;
+
+  /* to make the colour of the collapsable always dark*/
+  /* the collapsable doesnt follow the `always dark mode` rule*/
+  color: rgb(245, 246, 247);
 }
 
 /* padding for the brand on normal bar */
@@ -55,6 +60,12 @@ nav {
 .navbar-sidebar .navbar__brand {
   padding: 1rem 0rem;
   padding-left: 0rem;
+}
+
+/* to keep dark mode colours while in mobile mode*/
+/* it doesnt follow darkmode always rules while side panel*/
+.menu__link {
+  color: rgb(245, 246, 247);
 }
 
 /* Github logo */


### PR DESCRIPTION
### What are you trying to accomplish?
fixing the mobile nav bar issues 

the mobile nav bar doesnt follow the always dark theme rule set in `docusaurus.config.js` and so the font colours get weird.

i also added the github link and changed copy right to be `University of Windsor Computer Science Society`

### How are you accomplishing it?

the hamburger menu was an easy fix, just set the colour to what we want

the side menu nav fonts are alot more complicated. I had to use descendant matching attributes like `div a` but for classes.
that is because the side menu for docs reuses `menu__link` class. that means we can just put a blanket css rule on `menu__link` and so we have to specialize it to the nav bar. 

### Is there anything reviewers should know?
my solution for side nav bar fonts is pretty janky, it works but still. I tested it and didnt see anything broken about it on other pages or with the side menu for docs.



- [x] Is it safe to rollback this change if anything goes wrong?
