### PR TITLE
port over course offerings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+### Did you read and follow article requirements
+
 ### What are you trying to accomplish?
 
 

--- a/courses/index.md
+++ b/courses/index.md
@@ -3,18 +3,19 @@ id: index
 title: Index
 sidebar_label: Index
 slug: /
+hide_table_of_contents: true
 ---
 
-# Hello
+# Offered courses
 
-###### Requirements Legend
+### Requirements Legend
 
-❤️ Bachelor of Computer Science (General)<br/>
-💙 Bachelor of Computer Science (Honours)<br/>
-💛 Bachelor of Computer Science (Honours Applied Computing)<br/>
-💚 Bachelor of Science (Honours Computer Science with Software Engineering Specialization)<br/>
-💜 Bachelor of Commerce (Honours Business Administration and Computer Science)<br/>
-🖤 Bachelor of Mathematics (Honours Mathematics and Computer Science)<br/>
+❤️Bachelor of Computer Science (General)<br/>
+💙Bachelor of Computer Science (Honours)<br/>
+💛Bachelor of Computer Science (Honours Applied Computing)<br/>
+💚Bachelor of Science (Honours Computer Science with Software Engineering Specialization)<br/>
+💜Bachelor of Commerce (Honours Business Administration and Computer Science)<br/>
+🖤Bachelor of Mathematics (Honours Mathematics and Computer Science)<br/>
 
 | Course Code | Course Name | Fall | Winter | Summer | Required | Prerequisite(s)
 |-------------|:------------------------------------------------:|-------------|-------------|---------------------|----------|:------------------------------------------------------------------------------:|

--- a/courses/index.md
+++ b/courses/index.md
@@ -6,3 +6,68 @@ slug: /
 ---
 
 # Hello
+
+###### Requirements Legend
+
+❤️ Bachelor of Computer Science (General)<br/>
+💙 Bachelor of Computer Science (Honours)<br/>
+💛 Bachelor of Computer Science (Honours Applied Computing)<br/>
+💚 Bachelor of Science (Honours Computer Science with Software Engineering Specialization)<br/>
+💜 Bachelor of Commerce (Honours Business Administration and Computer Science)<br/>
+🖤 Bachelor of Mathematics (Honours Mathematics and Computer Science)<br/>
+
+| Course Code | Course Name | Fall | Winter | Summer | Required | Prerequisite(s)
+|-------------|:------------------------------------------------:|-------------|-------------|---------------------|----------|:------------------------------------------------------------------------------:|
+| COMP-1000 | Key Concepts in Computer Science | Offered | Offered | Offered | ❤️💙💛💚💜🖤| | 
+| COMP-1047 | Computer Concepts for End-Users | Offered | Offered | Offered |   |  |
+| COMP-1400 | Intro to Programming and Algorithms I | Offered | Offered | Offered | ❤️💙💛💚💜🖤|  |
+| COMP-1410 | Intro to Programming and Algorithms II | Offered | Offered | Offered | ❤️💙💛💚💜🖤| COMP-1000 or MATH-1720, COMP-1400 |   
+| COMP-2057 | Intro to the Internet | Offered | Offered | Offered | | COMP-1047 or COMP-2067 or COMP-1400|
+| COMP-2067 | Programming for Beginners | Offered | Offered | Offered | | |
+| COMP-2077 | Problem Solving and Information on the Internet | Offered | Not Offered | Offered | | COMP-1047, COMP-2057|
+| COMP-2097 | Social Media and Mobile Technology for End Users | Offered | Offered | Offered |  |  |
+| COMP-2120 | Object Oriented Programming Using Java | Offered | Offered | Offered | ❤️💙💛💚💜🖤| COMP-1410|
+| COMP-2140 | Computer Languages, Grammars and Translators | Not Offered | Offered | Not Offered | 💙💚🖤 | COMP-1000, COMP-2120 |
+| COMP-2310 | Theoretical Foundations of Computer Science | Offered | Offered | Not Offered | 💙💚🖤 | COMP-1000, MATH-1020 |
+| COMP-2540 | Data Structures and Algorithms | Offered | Offered | Offered | ❤️💙💛💚💜🖤| COMP-1000, COMP-1410 |
+| COMP-2560 | System Programming | Offered | Offered | Offered | ❤️💙💛💚💜🖤| COMP-1410 |
+| COMP-2650 | Computer Architecture I | Offered | Offered | Offered | ❤️💙💛💚💜🖤| COMP-1400 |
+| COMP-2660 | Computer Architecture II | Offered | Offered | Not Offered | ❤️💙💛💚 | COMP-2650 |
+| COMP-2707 | Advanced Website Design | Offered | Offered | Offered |  | COMP-2057 |
+| COMP-2800 | Software Development | Not Offered | Offered | Not Offered | 💚 | COMP-2120 |
+| COMP-3057 | Cyber-Ethics | Offered | Offered | Offered |  | COMP-1047, COMP-2057 |
+| COMP-3077 | Web-Based Data Management | Not Offered | Offered | Not Offered |  | COMP-2707 |
+| COMP-3110 | Introduction to Software Engineering | Offered | Not Offered | Not Offered | 💙💚 | COMP-2120, COMP-2540 |
+| COMP-3150 | Database Management Systems | Offered | Offered | Not Offered | ❤️💙💛💚💜🖤 | COMP-2540, COMP-2560 or COMP-2650 |
+| COMP-3220 | Obj Oriented Software Analysis and Design | Offered | Offered | Offered | ❤️💙💛💚 | COMP-2120, COMP-2540 |
+| COMP-3300 | Operating System Fundamentals | Not Offered | Offered | Offered | ❤️💙💛💚💜 | COMP-2120, COMP-2540, COMP-2560, COMP-2650 or COMP-2660 |
+| COMP-3340 | WWW Information System Development | Not Offered | Offered | Offered | ❤️💛💜 | COMP-2120, COMP-2540 |
+| COMP-3400 | Advanced Object Oriented System Design Using C++ | Not Offered | Offered | Not Offered | 💛 | COMP-2120, COMP-2560 |
+| COMP-3500 | Introduction to Multimedia Systems | Offered | Not Offered | Not Offered |  | COMP-2540, COMP-2650 |
+| COMP-3520 | Introduction to Computer Graphics | Not Offered | Offered | Not Offered |  | COMP-2540, MATH-1250 |
+| COMP-3540 | Theory of Computation | Offered | Not Offered | Not Offered | 💙💚 | COMP-2140, COMP-2310, COMP-2540 |
+| COMP-3670 | Computer Networks | Offered | Not Offered | Offered | 💙💛💚💜 | COMP-2120, COMP-2540, COMP-2560, COMP-2650 |
+| COMP-3680 | Network Practicum | Not Offered | Offered | Not Offered |  | COMP-3300, COMP-3670 |
+| COMP-3710 | Artificial Intelligence Concepts | Not Offered | Offered | Not Offered | | COMP-2540, STAT-2910 or STAT-2920 |
+| COMP-3770 | Game Design, Development, and Tools | Offered | Not Offered | Not Offered |  | COMP-2540, COMP-2120 |
+| COMP-4110 | Software Verification and Testing | Not Offered | Offered | Not Offered | 💚 | COMP-3110, COMP-3300 |
+| COMP-4150 | Advanced and Practical Database Systems | Offered | Not Offered | Not Offered | 💛 | COMP-3150, COMP-3300 |
+| COMP-4200 | Mobile Application Development | Not Offered | Offered | Not Offered | 💛 | COMP-3150, COMP-3220 |
+| COMP-4220 | Agile Software Development | Offered | Not Offered | Not Offered | 💛 | COMP-3220 |
+| COMP-4250 | Big Data Analytics and Database Design | Not Offered | Offered | Not Offered | 💛 | COMP-3150 |
+| COMP-4400 | Principles of Programming Languages | Offered | Not Offered | Not Offered | 💙💚 | COMP-2140, COMP-2310, COMP-2540 |
+| COMP-4540 | Design and Analysis of Algorithms | Offered | Offered | Not Offered | 💙💚 | COMP-2310, COMP-2540, COMP-3540 |
+| COMP-4670 | Network Security | Offered | Not Offered | Not Offered |  | COMP-3670 |
+| COMP-4680 | Advanced Networking | Not Offered | Offered | Not Offered |  | COMP-3670, COMP-3680 |
+| COMP-4730 | Machine Learning | Not Offered | Not Offered | Not Offered |  | COMP-3710 |
+| COMP-4740 | Advanced Topics in AI II | Not Offered | Offered | Not Offered |  | COMP-3710 |
+| COMP-4770 | Artifical Intelligence for Games | Not Offered | Offered | Not Offered |  | COMP-3770 |
+| COMP-4800 | Selected Topics in Software Engineering | Not Offered | Offered | Not Offered | 💚 | COMP-3110, COMP-3220, COMP-3300 |
+| COMP-4960 | Research Project | Offered | Offered | Not Offered | 💙💚 | |
+| COMP-4990 | Project Management: Techniques and Tools | Offered | Offered | Not Offered | 💙💛💚 | |
+| MATH-1020 | Mathematical Foundations | Not Offered | Offered | Offered | 💙💚 | One of COMP-1000, MATH-1250, MATH-1260 or MATH-1270 |
+| MATH-1250 | Linear Algebra I | Offered | Offered | Offered | 💙💚| |
+| MATH-1720 | Differential Calculus | Offered | Offered | Not Offered | 💙💚 | |
+| MATH-1730 | Integral Calculus | Not Offered | Offered | Offered | 💙💚 | MATH-1760 or MATH-1720 |
+| MATH-3940 | Numerical Analysis for Computer Scientists | Offered | Not Offered | Not Offered | 💙 | COMP-1410, MATH-1730 and one of MATH-1250, MATH-1260 or MATH-1270 |
+| STAT-2910 | Statistics for the Sciences | Offered | Offered | Offered | 💙💚 | |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,7 @@ module.exports = {
   projectName: 'Wiki', // Usually your repo name.
   themeConfig: {
     defaultMode: 'dark',
+	  hideableSidebar: true, 
     navbar: {
       style: 'dark',
       title: '',
@@ -75,7 +76,7 @@ module.exports = {
           items: [
             {
               label: 'Style Guide',
-              to: 'resources/style',
+              to: 'resources/guides/style',
             }
           ]
         },

--- a/resources/guides/contributing.md
+++ b/resources/guides/contributing.md
@@ -1,0 +1,6 @@
+---
+id: contributing
+title: How To Contribute
+sidebar_label: How To Contribute
+slug: /guides/contributing
+---

--- a/resources/guides/style_guide.md
+++ b/resources/guides/style_guide.md
@@ -2,7 +2,7 @@
 id: style_guide
 title: Style Guide
 sidebar_label: Style Guide
-slug: /style
+slug: /guides/style
 ---
 
 You can write content using [GitHub-flavored Markdown syntax](https://github.github.com/gfm/).
@@ -194,10 +194,10 @@ Reference-style: ![alt text][logo]
 
 Images from any folder can be used by providing path to file. Path should be relative to markdown file.
 
-![img](../static/img/logo.svg)
+![img](../../static/img/css-logo.png)
 
 ```
-![img](../static/img/logo.svg)
+![img](../../static/img/css-logo.png)
 ```
 
 ---

--- a/resources/resources_sidebars.js
+++ b/resources/resources_sidebars.js
@@ -5,8 +5,9 @@ module.exports = {
 			id: 'index',
 		},
 		{
-			type: 'doc',
-			id: 'style_guide',
+			type: 'category',
+			label: 'Guides',
+			items: ['guides/style_guide', 'guides/contributing'],
 		}
 	]
 };


### PR DESCRIPTION
### What are you trying to accomplish?
port over course offerings and some minor fixes including adding a question to the PR template and moving the style guide

### How are you accomplishing it?
porting over the course offerings has 2 big parts to it. 1 enabling side bars to be foldable, im not sure how this will effect accesibility but it shouldnt. and disabling the side table of contents in the courses section. with it enabled the div cuts off the table making it look weird, disabling it fixes that.

i also moved the style guide to `/guides` because thats where it will live

i also added a question to the PR template if they read and followed the requirements

### Is there anything reviewers should know?
naw


- [x] Is it safe to rollback this change if anything goes wrong?
