### PR TITLE
navbar styling now matches css hub and is nicer overall

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,7 @@
     --ifm-color-primary-lighter: rgb(102, 212, 189);
     --ifm-color-primary-lightest: rgb(146, 224, 208);
     --ifm-code-font-size: 95%;
+    --ifm-navbar-height: 80px;
 }
 
 .feature_link {
@@ -52,7 +53,7 @@ nav {
 /* padding for the brand on normal bar */
 .navbar__brand {
     padding: 1rem 0rem;
-    padding-left: 0.5rem;
+    padding-left: 1rem;
 }
 
 /* padding for right side of normal nav bar */
@@ -60,10 +61,9 @@ nav {
     padding-right: 0.5rem;
 }
 
-/* setting logo height and width so its full sized */
+/* setting logo height to match the CSS hub */
 .navbar__logo {
-    width: 8.826rem;
-    height: 3.5rem;
+    height: 4.32rem;
 }
 
 /* side bar header height */
@@ -74,7 +74,7 @@ nav {
 /* padding for the brand on the side bar */
 .navbar-sidebar .navbar__brand {
     padding: 1rem 0rem;
-    padding-left: 0rem;
+    padding-left: 1rem;
 }
 
 /* to keep dark mode colours while in mobile mode*/
@@ -102,4 +102,9 @@ nav {
     display: flex;
     background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
         no-repeat;
+}
+
+/* hamburger menu */
+.navbar__toggle {
+    padding-left: 1rem;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -106,5 +106,5 @@ nav {
 
 /* hamburger menu */
 .navbar__toggle {
-    padding-left: 1rem;
+    margin-left: 1rem;
 }


### PR DESCRIPTION
### What are you trying to accomplish?
Improve the navbar styling

### How are you accomplishing it?
Changing nav height and image height to match the CSS hub, adding padding to the hamburger menu

### Is there anything reviewers should know?
The screenshots may look a bit deceiving because chrome devtools has a similar background colour to the wiki. Look closely to see where it actually got cut off before my changes

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [x] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?

### Screenshots of Before Change
![image](https://user-images.githubusercontent.com/47261508/158732208-795e1531-a80c-453b-b6b4-06a676879d5c.png)
![image](https://user-images.githubusercontent.com/47261508/158732276-f304d345-d017-49b0-88d4-c703ff2fcd4d.png)
![image](https://user-images.githubusercontent.com/47261508/158732287-1fe220bc-dca6-4e7a-86cb-52f11c2a99e3.png)


### Screenshots of After Change
![image](https://user-images.githubusercontent.com/47261508/158732090-b4f46561-370b-4d33-92e7-4617e18e599d.png)
![image](https://user-images.githubusercontent.com/47261508/158732119-a816e9c6-3a6d-46fc-a49a-e56f8c20629a.png)
![image](https://user-images.githubusercontent.com/47261508/158732134-82aa7129-2eb6-4d3e-afa7-79a2ac536b44.png)

