### PR TITLE
Fix: feature icon not change with theme

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./styles.module.css";
-import useThemeContext from "@theme/hooks/useThemeContext";
+import ThemedImage from "@theme/ThemedImage";
 
 const features = [
     {
@@ -62,24 +62,20 @@ const features = [
 ];
 
 const Feature = ({imageUrl, linkTo, title, description}) => {
-    const {isDarkTheme, setLightTheme, setDarkTheme} = useThemeContext();
-
-    const theme = isDarkTheme ? "-dark.svg" : "-light.svg";
-
-    const imgUrl = useBaseUrl(imageUrl + theme);
-
-    // const themeStyle =
     return (
         <div className={clsx("col col--4", styles.feature)}>
             <Link href={linkTo} className={clsx("feature_link")}>
-                {imgUrl && (
+                {imageUrl && (
                     <div className="text--center">
-                        <img
+                        <ThemedImage
                             className={clsx(
                                 "feature_image",
                                 styles.featureImage
                             )}
-                            src={imgUrl}
+                            sources={{
+                                light: useBaseUrl(imageUrl + "-light.svg"),
+                                dark: useBaseUrl(imageUrl + "-dark.svg"),
+                            }}
                             alt={`${title} icon`}
                         />
                     </div>


### PR DESCRIPTION
### What are you trying to accomplish?
On init of the wiki, *sometimes* the `useThemeContext` hook returns the
wrong thing. This is mega super duper poopy and makes it look weird.

To fix this, I used the `ThemedImage` component. This component
correctly renders the image according to the theme. It also simplifies
our code.

### How are you accomplishing it?
Read above

### Is there anything reviewers should know?
This component is *under* documented. Its only documentation is at https://docusaurus.io/docs/next/markdown-features/assets#themed-images

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [x] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?
