### PR TITLE
added co-op sequence article

### DIFF
--- a/careers/careers_sidebars.js
+++ b/careers/careers_sidebars.js
@@ -14,6 +14,10 @@ module.exports = {
         },
         {
             type: "doc",
+            id: "coopsequence",
+        },
+        {
+            type: "doc",
             id: "findingajob",
         },
         {

--- a/careers/coopsequence.md
+++ b/careers/coopsequence.md
@@ -1,0 +1,47 @@
+---
+id: coopsequence
+title: Standard Co-Op Sequence
+sidebar_label: Standard Co-Op Sequence
+slug: /coop_sequence
+---
+
+_Last updated on 2022/03/21_
+
+## Standard Co-op Sequence
+
+The following course sequences is a general course sequence for the Co-Op programs:
+
+### Bachelor of Computer Science Honours / Bachelor of Science Honours Co-Op
+
+| SEMESTER | YEAR 1 | YEAR 2 | YEAR 3 | YEAR 4 | YEAR 5 |
+| -------- | :----: | :----: | :----: | :----: | :----: |
+| Fall     | STUDY  | STUDY  | STUDY  | CO-OP  | STUDY  |
+| Winter   | STUDY  | STUDY  | CO-OP  | STUDY  |        |
+| Summer   | BREAK  | CO-OP  | STUDY  | CO-OP  |        |
+
+The above course sequence applies to the following programs:
+
+-   Bachelor of Computer Science Honours Computer Science Co-op
+-   Bachelor of Computer Science Honours Applied Computing Co-op
+-   Bachelor of Science Honours Computer Information Systems Co-op
+-   Bachelor of Science Honours Computer Science with Software Engineering Specialization Co-op
+
+:::note
+The fourth work-term is optional. Only three work-terms are required for the Co-Op programs.
+:::
+
+---
+
+### Bachelor of Commerce Honours Business Administration and Computer Science Co-Op
+
+| SEMESTER | YEAR 1 | YEAR 2 | YEAR 3 | YEAR 4 |
+| -------- | :----: | :----: | :----: | :----: |
+| Fall     | STUDY  | STUDY  | STUDY  | CO-OP  |
+| Winter   | STUDY  | STUDY  | CO-OP  | STUDY  |
+| Summer   | BREAK  | CO-OP  | STUDY  | STUDY  |
+
+# Citations
+
+-   [0] https://www.uwindsor.ca/coop-workplace-partnerships/311/computer-science
+-   [1] https://www.uwindsor.ca/coop-workplace-partnerships/305/business-computer-science
+-   [2] Spring 2022 Undergraduate Academic Calendar


### PR DESCRIPTION
Found a workaround to Prettier returning exit code 1 on command: use Prettier plug-in on VSCode. The issue was from permission issues when running scripts from command line.

### What are you trying to accomplish?

Create an article that is about the standard co-op sequence for CS programs

### How are you accomplishing it?

By writing the article using Markdown and formatting using VSCode Prettier Plug-in. The modified files are 'careers_sidebar.js' and 'coopsequence.md' in '\wiki\careers'.

### Is there anything reviewers should know?

The command 'git ls-files --eol' shows that some of the files in the repo has \crlf ending. However, the website can be hosted on WSL without crashing, and these line endings are also found in the master branch. This might be an issue if this doesn't happen on Linux-based machines.

### Checks before you create your pull request

-   [Y] Did you read and follow article requirements?

-   [Y] Did you run prettier? Yes, using the VSCode Prettier Plug-in through format-on-save feature. Hopefully it works.

-   [Y] Is it safe to rollback this change if anything goes wrong?