### PR TITLE
Academics page sub pages map

### DIFF
--- a/academics/index.md
+++ b/academics/index.md
@@ -5,14 +5,14 @@ sidebar_label: Index
 slug: /
 ---
 
- -  [Important Dates](/academics/ImportantDates.md)
- -  Awards
+-   [Important Dates](/academics/ImportantDates.md)
+-   Awards
     -   [Finding Awards](/academics/awards/findingAwards.md)
     -   [Applying for Awards](/academics/awards/awardApplication.md)
- -  Research
+-   Research
     -   [Getting Involved with Research](/academics/research/doingresearch.md)
     -   [Outstanding Scholars](/academics/research/outstandingscholars.md)
- -  Support Resources
+-   Support Resources
     -   [Academic Support Resources](/academics/support/academicsupport.md)
     -   [Mental Health Resources](/academics/support/mentalhealth.md)
     -   [Physical Health Resources](/academics/support/physicalhealth.md)

--- a/academics/index.md
+++ b/academics/index.md
@@ -1,8 +1,18 @@
 ---
 id: index
-title: Index
+title: Academics
 sidebar_label: Index
 slug: /
 ---
 
-## hello from academics
+ - [Important Dates](/academics/ImportantDates.md)
+ - Awards
+	 - [Finding Awards](/academics/awards/findingAwards.md)
+	 - [Applying for Awards](/academics/awards/awardApplication.md)
+ - Research
+	 - [Getting Involved with Research](/academics/research/doingresearch.md)
+	 - [Outstanding Scholars](/academics/research/outstandingscholars.md)
+ - Support Resources
+	 - [Academic Support Resources](/academics/support/academicsupport.md)
+	 - [Mental Health Resources](/academics/support/mentalhealth.md)
+	 - [Physical Health Resources](/academics/support/physicalhealth.md)

--- a/academics/index.md
+++ b/academics/index.md
@@ -7,12 +7,12 @@ slug: /
 
  - [Important Dates](/academics/ImportantDates.md)
  - Awards
-	 - [Finding Awards](/academics/awards/findingAwards.md)
-	 - [Applying for Awards](/academics/awards/awardApplication.md)
+    - [Finding Awards](/academics/awards/findingAwards.md)
+	- [Applying for Awards](/academics/awards/awardApplication.md)
  - Research
-	 - [Getting Involved with Research](/academics/research/doingresearch.md)
-	 - [Outstanding Scholars](/academics/research/outstandingscholars.md)
+	- [Getting Involved with Research](/academics/research/doingresearch.md)
+    - [Outstanding Scholars](/academics/research/outstandingscholars.md)
  - Support Resources
-	 - [Academic Support Resources](/academics/support/academicsupport.md)
-	 - [Mental Health Resources](/academics/support/mentalhealth.md)
-	 - [Physical Health Resources](/academics/support/physicalhealth.md)
+	- [Academic Support Resources](/academics/support/academicsupport.md)
+	- [Mental Health Resources](/academics/support/mentalhealth.md)
+    - [Physical Health Resources](/academics/support/physicalhealth.md)

--- a/academics/index.md
+++ b/academics/index.md
@@ -5,14 +5,14 @@ sidebar_label: Index
 slug: /
 ---
 
- - [Important Dates](/academics/ImportantDates.md)
- - Awards
-    - [Finding Awards](/academics/awards/findingAwards.md)
-	- [Applying for Awards](/academics/awards/awardApplication.md)
- - Research
-	- [Getting Involved with Research](/academics/research/doingresearch.md)
-    - [Outstanding Scholars](/academics/research/outstandingscholars.md)
- - Support Resources
-	- [Academic Support Resources](/academics/support/academicsupport.md)
-	- [Mental Health Resources](/academics/support/mentalhealth.md)
-    - [Physical Health Resources](/academics/support/physicalhealth.md)
+ -  [Important Dates](/academics/ImportantDates.md)
+ -  Awards
+    -   [Finding Awards](/academics/awards/findingAwards.md)
+    -   [Applying for Awards](/academics/awards/awardApplication.md)
+ -  Research
+    -   [Getting Involved with Research](/academics/research/doingresearch.md)
+    -   [Outstanding Scholars](/academics/research/outstandingscholars.md)
+ -  Support Resources
+    -   [Academic Support Resources](/academics/support/academicsupport.md)
+    -   [Mental Health Resources](/academics/support/mentalhealth.md)
+    -   [Physical Health Resources](/academics/support/physicalhealth.md)


### PR DESCRIPTION
### What are you trying to accomplish?

Adding a sub-page map to the Academics page to make it easier for the user to navigate

### How are you accomplishing it?

### Screenshot

![Screen Shot 2022-08-13 at 3 17 31 PM](https://user-images.githubusercontent.com/72142523/184507763-4f15a954-9c43-4675-835e-ec480bea92fd.png)

### Is there anything reviewers should know?

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [x] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?
