### PR TITLE
added careers and resources pages sub-pages map

### DIFF
--- a/careers/index.md
+++ b/careers/index.md
@@ -4,3 +4,14 @@ title: Careers and Internships
 sidebar_label: Index
 slug: /
 ---
+
+-   [FAQ](/careers/faq.md)
+-   [Co-Op Versus Internship](/careers/choosing.md)
+-   [Is Co-Op Right For You?](/careers/choosingcoop.md)
+-   [Standard Co-Op Sequence](/careers/coopsequence.md)
+-   [Finding Jobs](/careers/findingjobs.md)
+-   [Cover Letters](/careers/coverletter.md)
+-   [Resumes](/careers/resume.md)
+-   [Interviews](/careers/interviewing.md)
+-   [Working in the United States](/careers/workinus.md)
+

--- a/resources/index.md
+++ b/resources/index.md
@@ -5,4 +5,13 @@ sidebar_label: Index
 slug: /
 ---
 
-# Hello from resources
+# Resources
+
+-   Guides
+    -   [Style Guide](/resources/guides/style_guide.md)
+    -   [How To Contribute](/resources/guides/contributing.md)
+    -   [Wi-Fi Guide](/resources/guides/wifi_guide.md)
+    -   [UWinsite Guide](/resources/guides/uwinsite_guide.md)
+    -   [Parking Guide](/resources/guides/parking_guide.md)
+    -   [Becoming a UWSA-Ratified Club](/resources/guides/uwsa_club.md)
+    -   [Student Exchange Guide](/resources/guides/student_exchange_guide.md)


### PR DESCRIPTION
### What are you trying to accomplish?

Adding a sub-page map to the careers and resources pages to make it easier for the user to navigate

### How are you accomplishing it?

### Screenshots

![Screen Shot 2022-08-13 at 4 22 51 PM](https://user-images.githubusercontent.com/72142523/184509622-fb1cf9a5-3a60-46f7-8610-498109563dc0.png)

![Screen Shot 2022-08-13 at 4 22 46 PM](https://user-images.githubusercontent.com/72142523/184509624-3b5798d5-be35-4e14-b078-88c3c8026d52.png)

### Is there anything reviewers should know?

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [x] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?
