### PR TITLE
Fix: home link always lighting up

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,6 +25,7 @@ module.exports = {
             items: [
                 {
                     to: "/",
+                    activeBaseRegex: "^/wiki/$",
                     label: "Home",
                     position: "left",
                 },


### PR DESCRIPTION
### What are you trying to accomplish?
Fix #103 

### How are you accomplishing it?
That is because nav bar api was done weirdly with docusaurus. It doesnt fully expose react router so there is weirdness. It doesnt have an exact match option so im forcing it.

I added regex to match `/wiki/` exactly to be lit up.

### Is there anything reviewers should know?
This would cause issues if we ever change the URL base.
### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [x] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?
