### PR TITLE
Add remaining course overview

### DIFF
--- a/courses/COMP-1000/Overview.md
+++ b/courses/COMP-1000/Overview.md
@@ -21,6 +21,7 @@ COMP-1000 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-There are no prerequesites for this class.
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-1047/Overview.md
+++ b/courses/COMP-1047/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 1047 - Overview
+sidebar_label: Overview (COMP-1047)
+slug: /COMP-1047/overview
+---
+
+## Course Title
+
+The title for COMP-1047 is "Computer Concepts for End-Users".
+
+## Course Description
+
+Introduction to the concepts of operation of a computer system, including hardware and software. Development of conceptual understanding of word processors, databases, spreadsheets, etc., and practical experience with their use. Networking concepts and data communication concepts will be introduced. The Internet will be introduced with students having access to internet resources. Management information systems including the systems development lifecycle will be discussed. Fundamental concepts of algorithm development and programming will be introduced. Hands-on experience with microcomputers as well as a distributed-computing environment will be involved. In addition to lecture time, laboratory/tutorial time may be scheduled as required. (May not be used to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours)
+
+## Typical Course Offering
+
+COMP-1047 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-1400/Overview.md
+++ b/courses/COMP-1400/Overview.md
@@ -21,6 +21,7 @@ COMP-1400 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-There are no prerequesites for this class.
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-1410/Overview.md
+++ b/courses/COMP-1410/Overview.md
@@ -21,6 +21,6 @@ COMP-1410 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1400 is a prerequesite for this class.
+COMP-1000 (or MATH-1720) and COMP-1400 are the prerequisites for this class.

--- a/courses/COMP-2057/Overview.md
+++ b/courses/COMP-2057/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2057 - Overview
+sidebar_label: Overview (COMP-2057)
+slug: /COMP-2057/overview
+---
+
+## Course Title
+
+The title for COMP-2057 is "Intro to the Internet".
+
+## Course Description
+
+Students will be introduced to the Internet as a global information infrastructure, including fundamental concepts in protocols and services, packaging of data, and data transmission. Common tools and multimedia such as HTML, CSS, and CMS, used for the development of websites will also be introduced. Web page design, quality, accessibility and security issues will be discussed. How Web browsers and search engines work will be demonstrated. Social networks and other current Internet applications will be examined. In addition to lecture time, laboratory/ tutorial time may be scheduled as required. (Prerequisite: COMP-1047 or COMP-2067 or COMP-1400.) (May not be used to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-2057 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-1047 or COMP-2067 or COMP-1400 is the prerequisite for this class.
+

--- a/courses/COMP-2067/Overview.md
+++ b/courses/COMP-2067/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2067 - Overview
+sidebar_label: Overview (COMP-2067)
+slug: /COMP-2067/overview
+---
+
+## Course Title
+
+The title for COMP-2067 is "Programming for Beginners".
+
+## Course Description
+
+This course introduces fundamental computer programming principles and structured programming concepts, with an emphasis on good programming. Stages of the software development cycles are introduced: analysis, design, implementation, debugging and deployment. May not be used to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours).
+
+## Typical Course Offering
+
+COMP-2067 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-2067/Overview.md
+++ b/courses/COMP-2067/Overview.md
@@ -11,7 +11,8 @@ The title for COMP-2067 is "Programming for Beginners".
 
 ## Course Description
 
-This course introduces fundamental computer programming principles and structured programming concepts, with an emphasis on good programming. Stages of the software development cycles are introduced: analysis, design, implementation, debugging and deployment. May not be used to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours).
+This course introduces fundamental computer programming principles and structured programming concepts, with an emphasis on good programming. Stages of the software development cycles are introduced: analysis, design, implementation, debugging and deployment. (May not be used to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours).
+
 
 ## Typical Course Offering
 

--- a/courses/COMP-2077/Overview.md
+++ b/courses/COMP-2077/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2077 - Overview
+sidebar_label: Overview (COMP-2077)
+slug: /COMP-2077/overview
+---
+
+## Course Title
+
+The title for COMP-2077 is "Problem Solving and Information on the Internet".
+
+## Course Description
+
+Students will be introduced to logic and critical appraisals including reasoning skills and critical thinking in the computer age. Problem solving and heuristics will be discussed including how to solve problems by coming up with the right strategies. Searching using Boolean logic to pinpoint useful and reliable information will be introduced. Methods for being self-critical and critical of web information in order to perform evaluations will be studied. (Prerequisites COMP-1047 and COMP-2057.) (This course may not be taken to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours a week.)
+
+## Typical Course Offering
+
+COMP-2077 is typically offered in the Fall and Summer semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-1047 and COMP-2057 are the prerequisites for this class.
+

--- a/courses/COMP-2097/Overview.md
+++ b/courses/COMP-2097/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2097 - Overview
+sidebar_label: Overview (COMP-2097)
+slug: /COMP-2097/overview
+---
+
+## Course Title
+
+The title for COMP-2097 is "Social Media and Mobile Technology for End Users".
+
+## Course Description
+
+This course provides review, analysis and use of social media and mobile technologies such as Instagram (tm), Facebook (tm), twitter (tm) LinkedIn (tm), texting, and using mobile devices such as laptops, ios (tm) devices, and Android devices. Topics to be covered include: a comprehensive review of available social media and mobile technology, use of social media and mobile technology for sharing of knowledge and for group interaction, security and privacy, ethical principles in social media, methods for analyzing end-user requirements for a social media application, strategies for designing, implementing, and maintaining an ethically-sound social media campaign, and measurement and assessment of social media analytics using industry standard tools and techniques. (This course may not be taken to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours).
+
+## Typical Course Offering
+
+COMP-2097 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-2120/Overview.md
+++ b/courses/COMP-2120/Overview.md
@@ -21,6 +21,7 @@ COMP-2120 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1410 is a prerequesite for this class.
+COMP-1410 is the prerequisite for this class.
+

--- a/courses/COMP-2140/Overview.md
+++ b/courses/COMP-2140/Overview.md
@@ -7,7 +7,7 @@ slug: /COMP-2140/overview
 
 ## Course Title
 
-The title for COMP-2140 is "Computer Languages, Grammars, and Translators".
+The title for COMP-2140 is "Computer Languages, Grammars and Translators".
 
 ## Course Description
 
@@ -15,12 +15,13 @@ Pragmatic and theoretical aspects of grammars, recognizers, and translators for 
 
 ## Typical Course Offering
 
-COMP-2140 is typically offered in the Winter semester only.
+COMP-2140 is typically offered in the Winter semester.
 
 ## Is a Textbook Required?
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1000 and COMP-2120 are prerequesites for this class.
+COMP-1000 and COMP-2120 are the prerequisites for this class.
+

--- a/courses/COMP-2310/Overview.md
+++ b/courses/COMP-2310/Overview.md
@@ -19,9 +19,8 @@ COMP-2310 is typically offered in the Fall and Winter semesters.
 
 ## Is a Textbook Required?
 
-No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+Yes, a textbook is absolutely required to pass this class.
 
 ## Prerequisites
 
 COMP-1000 and MATH-1020 are the prerequisites for this class.
-

--- a/courses/COMP-2310/Overview.md
+++ b/courses/COMP-2310/Overview.md
@@ -19,8 +19,9 @@ COMP-2310 is typically offered in the Fall and Winter semesters.
 
 ## Is a Textbook Required?
 
-Yes, a textbook is absolutely required to pass this class.
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1000 and MATH-1020 are prerequesites for this class.
+COMP-1000 and MATH-1020 are the prerequisites for this class.
+

--- a/courses/COMP-2540/Overview.md
+++ b/courses/COMP-2540/Overview.md
@@ -21,6 +21,7 @@ COMP-2540 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1000 and COMP-1410 are prerequesites for this class.
+COMP-1000 and COMP-1410 are the prerequisites for this class.
+

--- a/courses/COMP-2560/Overview.md
+++ b/courses/COMP-2560/Overview.md
@@ -21,6 +21,7 @@ COMP-2560 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1410 is a prerequesite for this class.
+COMP-1410 is the prerequisite for this class.
+

--- a/courses/COMP-2650/Overview.md
+++ b/courses/COMP-2650/Overview.md
@@ -7,7 +7,7 @@ slug: /COMP-2650/overview
 
 ## Course Title
 
-The title for COMP-2650 is "Computer Architecture I: Digital Design".
+The title for COMP-2650 is "Computer Architecture I".
 
 ## Course Description
 
@@ -21,6 +21,7 @@ COMP-2650 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-1400 is a prerequesite for this class.
+COMP-1400 is the prerequisite for this class.
+

--- a/courses/COMP-2660/Overview.md
+++ b/courses/COMP-2660/Overview.md
@@ -7,7 +7,7 @@ slug: /COMP-2660/overview
 
 ## Course Title
 
-The title for COMP-2660 is "Computer Architecture II: Microprocessor Programming".
+The title for COMP-2660 is "Computer Architecture II".
 
 ## Course Description
 
@@ -21,6 +21,7 @@ COMP-2660 is typically offered in the Fall and Winter semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-2650 is a prerequesite for this class.
+COMP-2650 is the prerequisite for this class.
+

--- a/courses/COMP-2707/Overview.md
+++ b/courses/COMP-2707/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2707 - Overview
+sidebar_label: Overview (COMP-2707)
+slug: /COMP-2707/overview
+---
+
+## Course Title
+
+The title for COMP-2707 is "Advanced Website Design".
+
+## Course Description
+
+This course is intended to teach the student about advanced website creation and to give an understanding of some of the technology behind websites, as well as an understanding of emerging web-related technologies. Topics covered will include JavaScript, Style Sheets, Dynamic HTML, XML, XHTML, Web Browser compatibility issues, and how web servers work. (Prerequisite: COMP-2057.) (This course may not be taken to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-2707 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2057 is the prerequisite for this class.
+

--- a/courses/COMP-2750/Overview.md
+++ b/courses/COMP-2750/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 2750 - Overview
+sidebar_label: Overview (COMP-2750)
+slug: /COMP-2750/overview
+---
+
+## Course Title
+
+The title for COMP-2750 is "Selected Topics".
+
+## Course Description
+
+Topics may differ from year to year. (Prerequisite: COMP-1000 or MATH-1720, and COMP-1410.) (May be repeated for credit if content changes.) (3 lecture hours or equivalent.)
+
+## Typical Course Offering
+
+COMP-2750 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-1000 or MATH-1720 and COMP-1410 are the prerequisites for this class.
+

--- a/courses/COMP-2800/Overview.md
+++ b/courses/COMP-2800/Overview.md
@@ -21,6 +21,7 @@ COMP-2800 is typically offered in the Winter semester.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-2120 is a prerequesite for this class.
+COMP-2120 is the prerequisite for this class.
+

--- a/courses/COMP-3057/Overview.md
+++ b/courses/COMP-3057/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3057 - Overview
+sidebar_label: Overview (COMP-3057)
+slug: /COMP-3057/overview
+---
+
+## Course Title
+
+The title for COMP-3057 is "Cyber-Ethics".
+
+## Course Description
+
+A number of key concerns about social welfare in our cyber age will be explored. Law, morality, public policy, and how these both influence and are influenced by the Internet will be examined. This course will critically appraise issues surrounding, but not limited to, free speech, property rights (especially intellectual property), privacy, security, and artificial intelligence. Issues raised by ethical theorists, policy makers, legal experts, and computer scientists will be analyzed in this course. (Prerequisites: COMP-1047 and COMP-2057.) (This course may not be taken to fulfill the major requirements of any major or joint major in Computer Science.)(3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3057 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-1047 and COMP-2057 are the prerequisites for this class.
+

--- a/courses/COMP-3077/Overview.md
+++ b/courses/COMP-3077/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3077 - Overview
+sidebar_label: Overview (COMP-3077)
+slug: /COMP-3077/overview
+---
+
+## Course Title
+
+The title for COMP-3077 is "Web-Based Data Management".
+
+## Course Description
+
+This non-major course is intended to teach students how to design and build interactive data-driven Web sites, by extending their knowledge of relevant programming concepts and techniques introduced in COMP-2707, and introducing new tools and techniques. Students will learn advanced use of PHP and MySQL to build objects and glue them together using protocols such as JSON, code libraries such as AJAX and jQuery, and learn how to incorporate APIs from Web service providers such as Google Maps. (Prerequisite: COMP-2707). (This course may not be taken to fulfill the major requirements of any major or joint major in Computer Science.) (3 lecture hours a week.)
+
+## Typical Course Offering
+
+COMP-3077 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2707 is the prerequisite for this class.
+

--- a/courses/COMP-3110/Overview.md
+++ b/courses/COMP-3110/Overview.md
@@ -21,6 +21,7 @@ COMP-3110 is typically offered in the Fall semester.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-2120 and COMP-2540 are prerequesites for this class.
+COMP-2120 and COMP-2540 are the prerequisites for this class.
+

--- a/courses/COMP-3150/Overview.md
+++ b/courses/COMP-3150/Overview.md
@@ -21,6 +21,7 @@ COMP-3150 is typically offered in the Fall and Winter semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-Prerequesites for this class are COMP-2540 and COMP-2560 or COMP-2650
+COMP-2560 or COMP-2650 and COMP-2540 are the prerequisites for this class.
+

--- a/courses/COMP-3220/Overview.md
+++ b/courses/COMP-3220/Overview.md
@@ -7,7 +7,7 @@ slug: /COMP-3220/overview
 
 ## Course Title
 
-The title for COMP-3220 is "Object-Oriented Software Analysis and Design".
+The title for COMP-3220 is "Obj Oriented Software Analysis and Design".
 
 ## Course Description
 
@@ -21,6 +21,7 @@ COMP-3220 is typically offered in all semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-COMP-2120 and COMP-2540 are prerequesites for this class.
+COMP-2540 and COMP-2120 are the prerequisites for this class.
+

--- a/courses/COMP-3300/Overview.md
+++ b/courses/COMP-3300/Overview.md
@@ -7,7 +7,7 @@ slug: /COMP-3300/overview
 
 ## Course Title
 
-The title for COMP-3300 is "Operating Systems Fundamentals".
+The title for COMP-3300 is "Operating System Fundamentals".
 
 ## Course Description
 
@@ -21,6 +21,7 @@ COMP-3300 is typically offered in the Winter and Summer semesters.
 
 No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
 
-## Prerequesites
+## Prerequisites
 
-Prerequesites for this class are COMP-2540, COMP-2120, COMP-2560, COMP-2650 or COMP-2660.
+COMP-2540, COMP-2120, COMP-2560, and COMP-2650 or COMP-2660 are the prerequisites for this class.
+

--- a/courses/COMP-3340/Overview.md
+++ b/courses/COMP-3340/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3340 - Overview
+sidebar_label: Overview (COMP-3340)
+slug: /COMP-3340/overview
+---
+
+## Course Title
+
+The title for COMP-3340 is "WWW Information System Development".
+
+## Course Description
+
+This course is designed for people who want to make their data available to others over the Internet. Topics will include WWW authoring, WWW site planning, executable programs that create dynamic documents, the client-server model, multi-tier WWW software architecture, and security aspects. (Prerequisite: COMP-2120 and COMP-2540.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3340 is typically offered in the Winter and Summer semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2540 and COMP-2120 are the prerequisites for this class.
+

--- a/courses/COMP-3400/Overview.md
+++ b/courses/COMP-3400/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3400 - Overview
+sidebar_label: Overview (COMP-3400)
+slug: /COMP-3400/overview
+---
+
+## Course Title
+
+The title for COMP-3400 is "Advanced Object Oriented System Design Using C++".
+
+## Course Description
+
+The main objective of this course is to explore advanced topics of the object oriented paradigm through the use of the C++ programming language. Topics covered include: advanced object oriented design, the use of abstraction to manage complexity, objects and classes, inheritance and class hierarchies, multiple inheritance, operator and method overloading, namespaces and visibility, templates, dynamic binding and virtual functions, exception handling, multi-threading and C++ standard library. In addition, the course will include a practical project, solving a real-life problem, implemented in C++, involving the client/server methodology, and an interface to a database using a graphics toolkit. (Prerequisites: COMP-2120, COMP-2560.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3400 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2560 and COMP-2120 are the prerequisites for this class.
+

--- a/courses/COMP-3500/Overview.md
+++ b/courses/COMP-3500/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3500 - Overview
+sidebar_label: Overview (COMP-3500)
+slug: /COMP-3500/overview
+---
+
+## Course Title
+
+The title for COMP-3500 is "Introduction to Multimedia Systems".
+
+## Course Description
+
+This course provides the student with basic concepts and techniques used in multimedia systems. Topics include: components of multimedia systems (text, audio, and video), media formats and standards, data compression techniques, hypermedia techniques, and authoring tools. (Prerequisite: COMP-2540 and COMP-2650.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3500 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2540 and COMP-2650 are the prerequisites for this class.
+

--- a/courses/COMP-3520/Overview.md
+++ b/courses/COMP-3520/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3520 - Overview
+sidebar_label: Overview (COMP-3520)
+slug: /COMP-3520/overview
+---
+
+## Course Title
+
+The title for COMP-3520 is "Introduction to Computer Graphics".
+
+## Course Description
+
+An introduction to computer graphics hardware and software, interfaces, standards, programming libraries, fundamental algorithms, rendering techniques, and algorithms for 2D and 3D applications. Substantial programming work is vital to this course. (Prerequisite: COMP-2540 and MATH-1250.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3520 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2540 and MATH-1250 are the prerequisites for this class.
+

--- a/courses/COMP-3540/Overview.md
+++ b/courses/COMP-3540/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3540 - Overview
+sidebar_label: Overview (COMP-3540)
+slug: /COMP-3540/overview
+---
+
+## Course Title
+
+The title for COMP-3540 is "Theory of Computation".
+
+## Course Description
+
+Finite Automata, regular expressions and languages; properties of regular languages; context-free grammars and languages; pushdown automata; properties of context-free languages. Introduction to Turing machines; recursive functions; undecidability. (Prerequisites: COMP-2140, COMP-2310 and COMP-2540.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3540 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2540, COMP-2310, and COMP-2140 are the prerequisites for this class.
+

--- a/courses/COMP-3670/Overview.md
+++ b/courses/COMP-3670/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3670 - Overview
+sidebar_label: Overview (COMP-3670)
+slug: /COMP-3670/overview
+---
+
+## Course Title
+
+The title for COMP-3670 is "Computer Networks".
+
+## Course Description
+
+This course is an introduction to computer networks and their protocols. Topics include: network architectures, transport, routing, and data link protocols, addressing, local area networks, flow and congestion control, and network security. Examples will be drawn primarily from the Internet (e.g. TCP, UDP, IP) protocol suite. (Prerequisite: COMP-2120, COMP-2540, COMP-2560 and COMP-2650. Recommended corequisite: COMP-3300.)
+
+## Typical Course Offering
+
+COMP-3670 is typically offered in the Fall and Summer semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2120, COMP-2540, COMP-2560, and COMP-2650 are the prerequisites for this class.
+

--- a/courses/COMP-3680/Overview.md
+++ b/courses/COMP-3680/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3680 - Overview
+sidebar_label: Overview (COMP-3680)
+slug: /COMP-3680/overview
+---
+
+## Course Title
+
+The title for COMP-3680 is "Network Practicum".
+
+## Course Description
+
+This course will acquaint the students with practical details of network software and hardware. Topics will include design, setup, configuration and implementation of various network functions. (Prerequisite: COMP-3300 and COMP-3670.) (3 lecture hours and 1.5 lab hours a week.)
+
+## Typical Course Offering
+
+COMP-3680 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3300 and COMP-3670 are the prerequisites for this class.
+

--- a/courses/COMP-3710/Overview.md
+++ b/courses/COMP-3710/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3710 - Overview
+sidebar_label: Overview (COMP-3710)
+slug: /COMP-3710/overview
+---
+
+## Course Title
+
+The title for COMP-3710 is "Artificial Intelligence Concepts".
+
+## Course Description
+
+This course covers fundamental concepts in Artificial Intelligence. Topics include informed and uninformed search, problem solving using propositional and first-order logics, knowledge representation and reasoning, plausible and uncertain reasoning, machine learning, ethical implications. An overview of some applied Artificial Intelligence such as natural language processing, planning and agent systems will be included. (Prerequisites:COMP-2540 and (STAT-2910 or STAT-2920) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3710 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+STAT-2910 or STAT-2920 and COMP-2540 are the prerequisites for this class.
+

--- a/courses/COMP-3770/Overview.md
+++ b/courses/COMP-3770/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 3770 - Overview
+sidebar_label: Overview (COMP-3770)
+slug: /COMP-3770/overview
+---
+
+## Course Title
+
+The title for COMP-3770 is "Game Design, Development, and Tools".
+
+## Course Description
+
+This course introduces professional game design and development tools. Students will become proficient in the use of a commercial grade game engine (e.g., Unity3D) and associated scripting/programming languages (e.g., C#) through programming intensive hands-on assignments. Topics may include game design and development concepts such as game objects and game components, game physics and collision handling, basic artificial intelligence, 2D and 3D graphics, textures and shaders, sprite animation, 3D animation, and audio. (Prerequisites: COMP-2540, COMP-2120.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-3770 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2540 and COMP-2120 are the prerequisites for this class.
+

--- a/courses/COMP-4110/Overview.md
+++ b/courses/COMP-4110/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4110 - Overview
+sidebar_label: Overview (COMP-4110)
+slug: /COMP-4110/overview
+---
+
+## Course Title
+
+The title for COMP-4110 is "Software Verification and Testing".
+
+## Course Description
+
+This course covers fundamental concepts and techniques for software verification and testing. The students will learn through practice the testing process, automated software testing tools, and various test models together with the related test coverage criteria. (Prerequisites: COMP-3110 and COMP-3300.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4110 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3110 and COMP-3300 are the prerequisites for this class.
+

--- a/courses/COMP-4150/Overview.md
+++ b/courses/COMP-4150/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4150 - Overview
+sidebar_label: Overview (COMP-4150)
+slug: /COMP-4150/overview
+---
+
+## Course Title
+
+The title for COMP-4150 is "Advanced and Practical Database Systems".
+
+## Course Description
+
+This course covers both advanced theoretical database materials as well as specific database application development tools needed in the industry. The course completes database design and theory initiated in COMP-3150 and then adds database application development languages. Students will be exposed to the running environments (e.g., their compilers) and applying these on the database theory and design of the first part to develop full application. (Prerequisites: COMP-3150 and COMP-3300.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4150 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3150 and COMP-3300 are the prerequisites for this class.
+

--- a/courses/COMP-4200/Overview.md
+++ b/courses/COMP-4200/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4200 - Overview
+sidebar_label: Overview (COMP-4200)
+slug: /COMP-4200/overview
+---
+
+## Course Title
+
+The title for COMP-4200 is "Mobile Application Development".
+
+## Course Description
+
+Students taking this course will learn how to create a mobile application for the Android platform. The topics covered will include: use of the mobile application development environment, specification of the requirements for a mobile application, design and implementation of the end-user interface, managing data in a mobile application environment, interfacing with data and programs residing on remote servers, creation of object-oriented programs to implement the mobile application, use of libraries and third-party software resources, deployment of a mobile application so that it is available to the public, and documentation, including creation of end-user instructions, and design/program documentation.Students will work individually, and will develop a mobile application that has been approved by the instructor of the course. (Prerequisites: COMP-3150, COMP-3220.) (3 lecture hours a week.)
+
+## Typical Course Offering
+
+COMP-4200 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3150 and COMP-3220 are the prerequisites for this class.
+

--- a/courses/COMP-4220/Overview.md
+++ b/courses/COMP-4220/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4220 - Overview
+sidebar_label: Overview (COMP-4220)
+slug: /COMP-4220/overview
+---
+
+## Course Title
+
+The title for COMP-4220 is "Agile Software Development".
+
+## Course Description
+
+This project-oriented course is designed to give students experience in developing projects using Agile software development process. The course will discuss principles of Agile methods for software development, with a concentration on the eXtreme Programming methodology, and will teach concepts related to its practices. Topics will include software and user interface design, build and development tools, data persistence, and proper software testing. Projects will involve the creation of industry-oriented software (e.g. in Java), and will expose participants to tools commonly used in industry. (Prerequisite: COMP-3220.)(3 lecture hours a week).
+
+## Typical Course Offering
+
+COMP-4220 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3220 is the prerequisite for this class.
+

--- a/courses/COMP-4250/Overview.md
+++ b/courses/COMP-4250/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4250 - Overview
+sidebar_label: Overview (COMP-4250)
+slug: /COMP-4250/overview
+---
+
+## Course Title
+
+The title for COMP-4250 is "Big Data Analytics and Database Design".
+
+## Course Description
+
+This course introduces topics in data mining and data analytics with emphasis on Big Data. Students will gain knowledge on the practical design principles as well as theoretical foundations of Big Data processing systems. Topics covered will include: data storage design and processing of big data systems such as NOSQL databases, MapReduce and Hadoop; introduction to data mining concepts such as frequent itemset and association rule mining, finding similar items, clustering, classification, link analysis, and mining data streams. (Prerequisite: COMP-3150) (3 lecture hours a week, plus unsupervised study and work on individual/group assignments or projects.)
+
+## Typical Course Offering
+
+COMP-4250 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3150 is the prerequisite for this class.
+

--- a/courses/COMP-4400/Overview.md
+++ b/courses/COMP-4400/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4400 - Overview
+sidebar_label: Overview (COMP-4400)
+slug: /COMP-4400/overview
+---
+
+## Course Title
+
+The title for COMP-4400 is "Principles of Programming Languages".
+
+## Course Description
+
+Basic concepts of programming languages. Comparative study of the major programming paradigms, including imperative, object-oriented, functional, logic, and concurrent programming. Principles of programming language design and evaluation. Syntax, semantics and implementation techniques of programming languages. (Prerequisite: COMP-2140, COMP-2310 and COMP-2540.) (Restricted to Computer Science students) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4400 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2140, COMP-2310, and COMP-2540 are the prerequisites for this class.
+

--- a/courses/COMP-4500/Overview.md
+++ b/courses/COMP-4500/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4500 - Overview
+sidebar_label: Overview (COMP-4500)
+slug: /COMP-4500/overview
+---
+
+## Course Title
+
+The title for COMP-4500 is "3D Multimedia System Development".
+
+## Course Description
+
+The aim of this course is to discuss and learn technologies for the development of multimedia application, modeling and development of standalone and/or, networked multimedia systems, and computer generated 3D animation. (Prerequisite: COMP-3500 or consent of instructor.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4500 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+Other requirements (see [1]) is the prerequisite for this class.
+

--- a/courses/COMP-4540/Overview.md
+++ b/courses/COMP-4540/Overview.md
@@ -19,9 +19,8 @@ COMP-4540 is typically offered in the Fall and Winter semesters.
 
 ## Is a Textbook Required?
 
-No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+Yes, a textbook is absolutely required to pass this class.
 
 ## Prerequisites
 
 COMP-2310, COMP-2540, and COMP-3540 are the prerequisites for this class.
-

--- a/courses/COMP-4540/Overview.md
+++ b/courses/COMP-4540/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4540 - Overview
+sidebar_label: Overview (COMP-4540)
+slug: /COMP-4540/overview
+---
+
+## Course Title
+
+The title for COMP-4540 is "Design and Analysis of Algorithms".
+
+## Course Description
+
+The intent of this course is to introduce the fundamental techniques in the design and analysis of computer algorithms. Topics include: asymptotic bounds, advanced data structures, searching, sorting, order statistics, oracle arguments, divide-and-conquer, greedy algorithms, dynamic programming, graph algorithms, NP completeness, and approximation algorithms. (Prerequisite: COMP-2310, COMP-2540 and COMP-3540.) (Restricted to Semester 7 and semester 8 students in Computer Science.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4540 is typically offered in the Fall and Winter semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-2310, COMP-2540, and COMP-3540 are the prerequisites for this class.
+

--- a/courses/COMP-4670/Overview.md
+++ b/courses/COMP-4670/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4670 - Overview
+sidebar_label: Overview (COMP-4670)
+slug: /COMP-4670/overview
+---
+
+## Course Title
+
+The title for COMP-4670 is "Network Security".
+
+## Course Description
+
+This course will introduce students to advanced topics in network security. Topics will include encryption and authentication techniques, detection and analysis of intrusions, and the security of electronic mail and web access. (Restricted to Computer Science students) (Prerequisites: COMP-3670.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4670 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3670 is the prerequisite for this class.
+

--- a/courses/COMP-4680/Overview.md
+++ b/courses/COMP-4680/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4680 - Overview
+sidebar_label: Overview (COMP-4680)
+slug: /COMP-4680/overview
+---
+
+## Course Title
+
+The title for COMP-4680 is "Advanced Networking".
+
+## Course Description
+
+The course will introduce students to advanced topics in networking. (Restricted to Computer Science Students) (Prerequisites: COMP-3670 and COMP-3680.)
+
+## Typical Course Offering
+
+COMP-4680 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3670 and COMP-3680 are the prerequisites for this class.
+

--- a/courses/COMP-4730/Overview.md
+++ b/courses/COMP-4730/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4730 - Overview
+sidebar_label: Overview (COMP-4730)
+slug: /COMP-4730/overview
+---
+
+## Course Title
+
+The title for COMP-4730 is "Advanced Topics in AI I".
+
+## Course Description
+
+The course will introduce students to advanced topics in Artificial Intelligence. (Restricted to Honours Computer Science students) (Prerequisite: COMP-3710.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4730 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3710 is the prerequisite for this class.
+

--- a/courses/COMP-4740/Overview.md
+++ b/courses/COMP-4740/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4740 - Overview
+sidebar_label: Overview (COMP-4740)
+slug: /COMP-4740/overview
+---
+
+## Course Title
+
+The title for COMP-4740 is "Advanced Topics in AI II".
+
+## Course Description
+
+The course will introduce students to advanced topics in Artificial Intelligence. (Restricted to Honours Computer Science students.) (Prerequisite: COMP-3710.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4740 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3710 is the prerequisite for this class.
+

--- a/courses/COMP-4770/Overview.md
+++ b/courses/COMP-4770/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4770 - Overview
+sidebar_label: Overview (COMP-4770)
+slug: /COMP-4770/overview
+---
+
+## Course Title
+
+The title for COMP-4770 is "Artifical Intelligence for Games".
+
+## Course Description
+
+This course provides students with an opportunity to explore theoretical and practical aspects of Artificial Intelligence for computer games. Topics may include agents, sensory systems, steering behaviours, pathfinding, decision making, planning, goal-oriented behaviour, multi-agents (groups, crowds) and learning. (This course could be used to satisfy the COMP-4730 (fourth year AI) requirement.) (Prerequisite: COMP-3770.) (Restricted to students in Honours Computer Science.) (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4770 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3770 is the prerequisite for this class.
+

--- a/courses/COMP-4800/Overview.md
+++ b/courses/COMP-4800/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4800 - Overview
+sidebar_label: Overview (COMP-4800)
+slug: /COMP-4800/overview
+---
+
+## Course Title
+
+The title for COMP-4800 is "Selected Topics in Software Engineering".
+
+## Course Description
+
+This course intends to connect emerging technologies with the student's theoretical background in Computer Science related to Software Engineering concepts and techniques. Selected application domains include protocol security, web systems and distributed object systems and the theories involved include graph theory, set theory, automata and compiler theory. (Prerequisite: COMP-3110, COMP-3220 and COMP-3300.) (Restricted to Computer Science Students). (3 lecture hours a week)
+
+## Typical Course Offering
+
+COMP-4800 is typically offered in the Winter semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-3110, COMP-3220, and COMP-3300 are the prerequisites for this class.
+

--- a/courses/COMP-4960/Overview.md
+++ b/courses/COMP-4960/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4960 - Overview
+sidebar_label: Overview (COMP-4960)
+slug: /COMP-4960/overview
+---
+
+## Course Title
+
+The title for COMP-4960 is "Research Project".
+
+## Course Description
+
+This course consists of two components: a) development of research skills, and b) development of technical writing and project presentation skills. This course requires students to complete a research project in some area of Computer Science under the supervision of a faculty member. The course will typically involve the development of some software or the design and/or implementation of some algorithm. Each student will be required to submit a project report and give one or more seminars on the research project. (a 6 credit course restricted to Semester 7 or Semester 8 students in BCS (Honours) or B.Sc. (Honours Computer Science with Software Engineering Specialization) with a major average of 8.0 or better). (Anti-requisite COMP-4990.) (3 lecture hours or equivalent a week, for two terms
+
+## Typical Course Offering
+
+COMP-4960 is typically offered in the Fall and Winter semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/COMP-4990/Overview.md
+++ b/courses/COMP-4990/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: COMP 4990 - Overview
+sidebar_label: Overview (COMP-4990)
+slug: /COMP-4990/overview
+---
+
+## Course Title
+
+The title for COMP-4990 is "Project Management: Techniques and Tools".
+
+## Course Description
+
+This course requires students to complete an application development project in some area of Computer Science under the supervision of a faculty member. The course will typically involve the development of some software or the design and/or implementation of some algorithm. Each student will be required to submit a project report and give one or more seminars on the system development project. (a 6 credit course restricted to Semester 7 or Semester 8 students in Computer Science.) (Antirequisite: COMP-4960.) (3 lecture hours or equivalent a week, for two terms.
+
+## Typical Course Offering
+
+COMP-4990 is typically offered in the Fall and Winter semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/MATH-1020/Overview.md
+++ b/courses/MATH-1020/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: MATH 1020 - Overview
+sidebar_label: Overview (MATH-1020)
+slug: /MATH-1020/overview
+---
+
+## Course Title
+
+The title for MATH-1020 is "Mathematical Foundations".
+
+## Course Description
+
+This course will cover mathematical logic, proof methods and development of proof techniques, mathematical induction, sets, equivalence relations, partial ordering relations and functions. (Prerequisite: One of COMP-1000, MATH-1250, MATH-1260 or MATH-1270.) (2 lecture hours, 2 tutorial hours per week.)
+
+## Typical Course Offering
+
+MATH-1020 is typically offered in the Winter and Summer semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+COMP-1000 or MATH-1250 or MATH-1260 or MATH-1270 is the prerequisite for this class.
+

--- a/courses/MATH-1250/Overview.md
+++ b/courses/MATH-1250/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: MATH 1250 - Overview
+sidebar_label: Overview (MATH-1250)
+slug: /MATH-1250/overview
+---
+
+## Course Title
+
+The title for MATH-1250 is "Linear Algebra I".
+
+## Course Description
+
+This course will cover linear systems, matrix algebra, determinants, n-dimensional vectors, dot product, cross product, orthogonalization, eigenvalues, eigenvectors, diagonalization and vector spaces. (Prerequisites: Both Ontario Grade 12 Advanced Functions (MHF4U) and Calculus and Vectors (MCV4U) or MATH-1280.) (Antirequisites: MATH-1260, MATH-1270.) (3 lecture hours, 2 tutorial hours per week.)
+
+## Typical Course Offering
+
+MATH-1250 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/MATH-1720/Overview.md
+++ b/courses/MATH-1720/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: MATH 1720 - Overview
+sidebar_label: Overview (MATH-1720)
+slug: /MATH-1720/overview
+---
+
+## Course Title
+
+The title for MATH-1720 is "Differential Calculus".
+
+## Course Description
+
+This course will cover trigonometric functions and identities, inverse trigonometric functions, limits and continuity, derivatives and applications, mean value theorem, indeterminate forms and lHpitals rule, antiderivatives and an introduction to definite integrals. This course is for students who have taken both Ontario Grade 12 Advanced Functions (MHF4U) and Ontario Grade 12 Calculus and Vectors (MCV4U). Students who do not have credit for MCV4U should take MATH-1760. (Prerequisites: Ontario Grade 12 Advanced Functions (MHF4U) and Ontario Grade 12 Calculus and Vectors (MCV4U) or MATH-1780.) (Antirequisite: MATH-1760.) (3 lecture hours, 2 tutorial hours per week.)
+
+## Typical Course Offering
+
+MATH-1720 is typically offered in the Fall and Winter semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/MATH-1730/Overview.md
+++ b/courses/MATH-1730/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: MATH 1730 - Overview
+sidebar_label: Overview (MATH-1730)
+slug: /MATH-1730/overview
+---
+
+## Course Title
+
+The title for MATH-1730 is "Integral Calculus".
+
+## Course Description
+
+This course will cover antiderivatives, the definite integral and the fundamental theorem of calculus, techniques of integration, applications, improper integrals, sequences and series, convergence tests, power series, Taylor and Maclaurin series, and polar and parametric coordinates. (Prerequisite: MATH-1760 or MATH-1720.) (3 lecture hours, 1 tutorial hour per week.)
+
+## Typical Course Offering
+
+MATH-1730 is typically offered in the Winter and Summer semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+MATH-1760 or MATH-1720 is the prerequisite for this class.
+

--- a/courses/MATH-3940/Overview.md
+++ b/courses/MATH-3940/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: MATH 3940 - Overview
+sidebar_label: Overview (MATH-3940)
+slug: /MATH-3940/overview
+---
+
+## Course Title
+
+The title for MATH-3940 is "Numerical Analysis for Computer Scientists".
+
+## Course Description
+
+This course is an introduction to the applications of numerical methods using computer-oriented algorithms such as finding roots, solving systems of equations, differentiation, integration and optimization. (Restricted to students in Computer Science.) (Prerequisites: COMP-1410, MATH-1730 and one of MATH-1250, MATH-1260 or MATH-1270.) (3 lecture hours per week)
+
+## Typical Course Offering
+
+MATH-3940 is typically offered in the Fall semester.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+MATH-1250 or MATH-1260 or MATH-1270, COMP-1410, and MATH-1730 are the prerequisites for this class.
+

--- a/courses/STAT-2910/Overview.md
+++ b/courses/STAT-2910/Overview.md
@@ -1,0 +1,27 @@
+---
+id: overview
+title: STAT 2910 - Overview
+sidebar_label: Overview (STAT-2910)
+slug: /STAT-2910/overview
+---
+
+## Course Title
+
+The title for STAT-2910 is "Statistics for the Sciences".
+
+## Course Description
+
+This course will cover descriptive statistics, probability, discrete and continuous distributions, point and interval estimation, hypothesis testing, goodness-of-fit and contingency tables. (Prerequisite: Grade 12 U Advanced Level Mathematics (MHF4U, MCV4U, MDM4U) or Grade 11 Functions and Applications (MCF3M) or Grade 11 Functions (MCR3U).) (Course equivalencies and antirequisites as stated in the University of Windsor Senate Policy on Introductory Statistics Courses.) (May not be taken for credit after taking STAT-2920 or STAT-2950.) (3 lecture hours, 1 tutorial hour per week.)
+
+## Typical Course Offering
+
+STAT-2910 is typically offered in all semesters.
+
+## Is a Textbook Required?
+
+No, while there is a textbook listed and you may find it helpful, it is not required to succeed in this course.
+
+## Prerequisites
+
+There is no UWindsor prerequisite for this class.
+

--- a/courses/courses_sidebars.js
+++ b/courses/courses_sidebars.js
@@ -13,85 +13,314 @@ module.exports = {
                 "course_planning/specialcourse",
             ],
         },
-
         {
             type: "category",
-            label: "COMP-1000",
-            items: ["COMP-1000/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-1400",
-            items: ["COMP-1400/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-1410",
-            items: ["COMP-1410/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-2120",
-            items: ["COMP-2120/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-2140",
+            label: "Year 1 Computer Science Courses",
             items: [
-                "COMP-2140/overview",
-                "COMP-2140/installingJLex",
-                "COMP-2140/installingJavaCup",
+                {
+                    type: "category",
+                    label: "COMP-1000",
+                    items: ["COMP-1000/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-1047",
+                    items: ["COMP-1047/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-1400",
+                    items: ["COMP-1400/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-1410",
+                    items: ["COMP-1410/overview"],
+                },
             ],
         },
         {
             type: "category",
-            label: "COMP-2310",
-            items: ["COMP-2310/overview", "COMP-2310/surviving2310"],
+            label: "Year 2 Computer Science Courses",
+            items: [
+                {
+                    type: "category",
+                    label: "COMP-2057",
+                    items: ["COMP-2057/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2067",
+                    items: ["COMP-2067/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2077",
+                    items: ["COMP-2077/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2097",
+                    items: ["COMP-2097/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2120",
+                    items: ["COMP-2120/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2140",
+                    items: [
+                        "COMP-2140/overview",
+                        "COMP-2140/installingJLex",
+                        "COMP-2140/installingJavaCup",
+                    ],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2310",
+                    items: ["COMP-2310/overview", "COMP-2310/surviving2310"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2540",
+                    items: ["COMP-2540/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2560",
+                    items: ["COMP-2560/overview", "COMP-2560/advice"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2650",
+                    items: ["COMP-2650/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2660",
+                    items: ["COMP-2660/overview", "COMP-2660/easyMASM"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2707",
+                    items: ["COMP-2707/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2750",
+                    items: ["COMP-2750/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-2800",
+                    items: ["COMP-2800/overview"],
+                },
+            ],
         },
         {
             type: "category",
-            label: "COMP-2540",
-            items: ["COMP-2540/overview"],
+            label: "Year 3 Computer Science Courses",
+            items: [
+                {
+                    type: "category",
+                    label: "COMP-3057",
+                    items: ["COMP-3057/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3077",
+                    items: ["COMP-3077/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3110",
+                    items: ["COMP-3110/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3150",
+                    items: ["COMP-3150/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3220",
+                    items: ["COMP-3220/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3300",
+                    items: ["COMP-3300/overview", "COMP-3300/advice"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3340",
+                    items: ["COMP-3340/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3400",
+                    items: ["COMP-3400/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3500",
+                    items: ["COMP-3500/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3520",
+                    items: ["COMP-3520/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3540",
+                    items: ["COMP-3540/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3670",
+                    items: ["COMP-3670/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3680",
+                    items: ["COMP-3680/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3710",
+                    items: ["COMP-3710/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-3770",
+                    items: ["COMP-3770/overview"],
+                },
+            ],
         },
         {
             type: "category",
-            label: "COMP-2560",
-            items: ["COMP-2560/overview", "COMP-2560/advice"],
+            label: "Year 4 Computer Science Courses",
+            items: [
+                {
+                    type: "category",
+                    label: "COMP-4110",
+                    items: ["COMP-4110/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4150",
+                    items: ["COMP-4150/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4200",
+                    items: ["COMP-4200/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4220",
+                    items: ["COMP-4220/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4250",
+                    items: ["COMP-4250/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4400",
+                    items: ["COMP-4400/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4500",
+                    items: ["COMP-4500/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4540",
+                    items: ["COMP-4540/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4670",
+                    items: ["COMP-4670/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4680",
+                    items: ["COMP-4680/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4730",
+                    items: ["COMP-4730/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4740",
+                    items: ["COMP-4740/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4770",
+                    items: ["COMP-4770/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4800",
+                    items: ["COMP-4800/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4960",
+                    items: ["COMP-4960/overview"],
+                },
+                {
+                    type: "category",
+                    label: "COMP-4990",
+                    items: ["COMP-4990/overview"],
+                },
+            ],
         },
         {
             type: "category",
-            label: "COMP-2650",
-            items: ["COMP-2650/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-2660",
-            items: ["COMP-2660/overview", "COMP-2660/easyMASM"],
-        },
-        {
-            type: "category",
-            label: "COMP-2800",
-            items: ["COMP-2800/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-3110",
-            items: ["COMP-3110/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-3150",
-            items: ["COMP-3150/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-3220",
-            items: ["COMP-3220/overview"],
-        },
-        {
-            type: "category",
-            label: "COMP-3300",
-            items: ["COMP-3300/overview", "COMP-3300/advice"],
+            label: "Math and Stats Courses",
+            items: [
+                {
+                    type: "category",
+                    label: "MATH-1020",
+                    items: ["MATH-1020/overview"],
+                },
+                {
+                    type: "category",
+                    label: "MATH-1250",
+                    items: ["MATH-1250/overview"],
+                },
+                {
+                    type: "category",
+                    label: "MATH-1720",
+                    items: ["MATH-1720/overview"],
+                },
+                {
+                    type: "category",
+                    label: "MATH-1730",
+                    items: ["MATH-1730/overview"],
+                },
+                {
+                    type: "category",
+                    label: "MATH-3940",
+                    items: ["MATH-3940/overview"],
+                },
+                {
+                    type: "category",
+                    label: "STAT-2910",
+                    items: ["STAT-2910/overview"],
+                },
+            ],
         },
     ],
 };


### PR DESCRIPTION
### What are you trying to accomplish?

Add the remaining course overview articles.

### How are you accomplishing it?

I wrote a python program that generated these articles based on the information in course.json and Jeremie's UWin API.

### Is there anything reviewers should know?

I think the sidebar is too cluttered with this many courses, so I put them into folders depending on whether they are CS courses and what year-level they're in.

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [ ] Did you run prettier? I tried to format them like the previous articles so it probably will be fine
-   [x] Is it safe to rollback this change if anything goes wrong?
