### PR TITLE
Add 4960 vs 4990 article and minor changes

### DIFF
--- a/courses/comp-4400/overview.md
+++ b/courses/comp-4400/overview.md
@@ -15,7 +15,7 @@ Basic concepts of programming languages. Comparative study of the major programm
 
 ## Typical Course Offering
 
-COMP-4400 is typically offered in the Fall semester.
+COMP-4400 is typically offered in the Fall and Winter semesters.
 
 ## Is a Textbook Required?
 

--- a/courses/comp-4540/overview.md
+++ b/courses/comp-4540/overview.md
@@ -23,4 +23,4 @@ Yes, a textbook is absolutely required to pass this class.
 
 ## Prerequisites
 
-COMP-2310, COMP-2540, and COMP-3540 are the prerequisites for this class.
+COMP-2310 and COMP-2540 are the prerequisites for this class.

--- a/courses/course-planning/4960vs4990.md
+++ b/courses/course-planning/4960vs4990.md
@@ -1,0 +1,54 @@
+---
+id: 4960vs4990
+title: COMP-4960 vs COMP-4990
+sidebar_label: COMP-4960 vs COMP-4990
+slug: /course-planning/4960vs4990
+---
+
+_Last updated on 2024/03/19_
+
+Many computer science students are required to take either COMP-4960 or COMP-4990 as a capstone style course. Both courses are taken over 2 semesters, and you can take either to satisfy your degree requirements (but not both). So which one do you choose? A brief comparison is given below.
+
+:::note
+
+Most students take COMP-4990, unless they have a specific reason to take COMP-4960 (e.g. they want to work on research oriented project under a particular faculty member, and that faculty member is willing to supervise them).
+:::
+
+## What is the Same in Both Courses?
+Both are 2 semester courses.
+
+They are anti-requisites (you can take one or the other to satisfy your degree, but not both).
+
+They are typically taken during the last 2 semesters of your degree.
+
+They are typically taken in consecutive semesters but exceptions can be made.
+
+You will work on a project supervised by a **faculty member** in the School of Computer Science.
+
+The workload will depend _greatly_ on your project and supervisor. For example, the number of meetings you have with your supervisor can vary from weekly meetings and progress reports to a handful of meetings throughout the entire course.
+
+You will be required to attend seminars for a small percentage of your grade. What counts as a seminar: weekly colloquiums always count, while thesis proposals and defenses may count **at the discretion of the course coordinator**. This may differ between COMP-4960 and COMP-4990 even in the same semester.
+
+You will be required to write some kind of report on your project.
+
+You will present your project at the end of your second semester with other COMP-4960 and COMP-4990 students.
+
+
+## What is Unique to COMP-4960?
+The student is required to seek out a faculty member willing to supervise them. They also need to come up with their project which must be approved by their supervisor.
+
+Projects are typically not done in groups.
+
+Projects are typically more research / theory oriented.
+
+You will need to attend 10 seminars and write a short summary for each.
+
+
+## What is Unique to COMP-4990?
+A list of projects and supervisors will be provided and students will be able to choose from this list.
+
+Projects are typically done in groups.
+
+Projects are typically more practical / application oriented.
+
+You will need to attend 12 seminars and write a short summary for 2.

--- a/courses/courses-sidebars.js
+++ b/courses/courses-sidebars.js
@@ -12,6 +12,7 @@ module.exports = {
                 "course-planning/degree-requirements",
                 "course-planning/electives",
                 "course-planning/special-course",
+                "course-planning/4960vs4990"
             ],
         },
         {

--- a/courses/offering/courses.json
+++ b/courses/offering/courses.json
@@ -377,7 +377,7 @@
             "winter": true,
             "summer": false,
             "required": ["CSH", "CSSE"],
-            "prerequisites": ["COMP-2310", "COMP-2540", "COMP-3540"]
+            "prerequisites": ["COMP-2310", "COMP-2540"]
         },
         {
             "course code": "COMP-4670",


### PR DESCRIPTION
### What are you trying to accomplish?
- Add COMP-4960 vs COMP-4990 comparison article (#174)
- Fix 4400 overview to mention it is now offered in fall and winter
- Change 4540 pages to remove 3540 as a prereq

### How are you accomplishing it?
Wrote article and modified other pages

### Is there anything reviewers should know?
The new article could probably be formatted better with a table but I'm lazy

### Checks before you create your pull request

-   [x] Did you read and follow article requirements?
-   [ ] Did you run prettier?
-   [x] Is it safe to rollback this change if anything goes wrong?
